### PR TITLE
feat: Update CMR XML metadata to define ACCODE v3.5.2 for LaSRC

### DIFF
--- a/metadata_creator/templates/L30.json
+++ b/metadata_creator/templates/L30.json
@@ -153,7 +153,7 @@
 				"Name": "ACCODE",
 				"DataType": "STRING",
 				"Description": " LaSRC Version",
-                                "Values": ["LaSRC v3.5.1"]
+                                "Values": ["LaSRC v3.5.2"]
 			},
 			{
 				"Name": "TIRS_SSM_MODEL",

--- a/metadata_creator/templates/S30.json
+++ b/metadata_creator/templates/S30.json
@@ -228,7 +228,7 @@
 				"Name": "ACCODE",
 				"DataType": "STRING",
 				"Description": "LaSRC Version",
-                                "Values": ["LaSRC v3.5.1"]
+                                "Values": ["LaSRC v3.5.2"]
 			},
 			{
 				"Name": "PROCESSING_BASELINE",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="metadata_creator",
-    version="0.1",
+    version="2.7",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
+++ b/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
@@ -205,7 +205,7 @@
     <AdditionalAttribute>
       <Name>ACCODE</Name>
       <Values>
-        <Value>LaSRC v3.5.1</Value>
+        <Value>LaSRC v3.5.2</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>

--- a/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
+++ b/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
@@ -309,7 +309,7 @@
     <AdditionalAttribute>
       <Name>ACCODE</Name>
       <Values>
-        <Value>LaSRC v3.5.1</Value>
+        <Value>LaSRC v3.5.2</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>

--- a/tests/data/HLS.S30.T48UXF.2020274T041601.v1.5.xml
+++ b/tests/data/HLS.S30.T48UXF.2020274T041601.v1.5.xml
@@ -267,7 +267,7 @@
     <AdditionalAttribute>
       <Name>ACCODE</Name>
       <Values>
-        <Value>LaSRC v3.5.1</Value>
+        <Value>LaSRC v3.5.2</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>


### PR DESCRIPTION
This PR updates the process that creates the CMR XML metadata to point to the updated LaSRC version from https://github.com/NASA-IMPACT/espa-surface-reflectance/pull/17 that includes a fix for the fill value handling bug. I had thought that this was automagically inherited from the `SR_VERSION` definition in LaSRC ([source](https://github.com/NASA-IMPACT/espa-surface-reflectance/blob/eros-collection2-3.5.2/lasrc/c_version/src/common.h#L17)) but

This "ACCODE" (atmospheric correction code version) metadata detail is defined in a few places,

* The CMR XML value for ACCODE is defined in this repo (e.g., `LaSRC v3.5.2`)
* Landsat output COG metadata ACCODE is defined,
    * in `hls-landsat` for adding FMask subdataset
    * in `hls-landsat-tile` (unclear if it's used here, but it looks like the definition is inherited from the HDF SDS metadata)
    * This currently just defines `ACCODE=Lasrc ; Lasrc` (for 2 path/rows ~> 1 MGRS tile)
* Sentinel-2 output COG metadata ACCODE is defined in the processing script during HDF creation phase
    * This currently just defines `ACCODE=LaSRC`

After merging this PR will become release v2.7