### PR TITLE
fix: version tag for LaSRC we're using for our fork

### DIFF
--- a/metadata_creator/templates/L30.json
+++ b/metadata_creator/templates/L30.json
@@ -153,7 +153,7 @@
 				"Name": "ACCODE",
 				"DataType": "STRING",
 				"Description": " LaSRC Version",
-                                "Values": ["LaSRC v3.5.2"]
+                                "Values": ["LaSRC v3.5.1.0"]
 			},
 			{
 				"Name": "TIRS_SSM_MODEL",

--- a/metadata_creator/templates/S30.json
+++ b/metadata_creator/templates/S30.json
@@ -228,7 +228,7 @@
 				"Name": "ACCODE",
 				"DataType": "STRING",
 				"Description": "LaSRC Version",
-                                "Values": ["LaSRC v3.5.2"]
+                                "Values": ["LaSRC v3.5.1.0"]
 			},
 			{
 				"Name": "PROCESSING_BASELINE",

--- a/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
+++ b/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
@@ -205,7 +205,7 @@
     <AdditionalAttribute>
       <Name>ACCODE</Name>
       <Values>
-        <Value>LaSRC v3.5.2</Value>
+        <Value>LaSRC v3.5.1.0</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>

--- a/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
+++ b/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
@@ -309,7 +309,7 @@
     <AdditionalAttribute>
       <Name>ACCODE</Name>
       <Values>
-        <Value>LaSRC v3.5.2</Value>
+        <Value>LaSRC v3.5.1.0</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>

--- a/tests/data/HLS.S30.T48UXF.2020274T041601.v1.5.xml
+++ b/tests/data/HLS.S30.T48UXF.2020274T041601.v1.5.xml
@@ -267,7 +267,7 @@
     <AdditionalAttribute>
       <Name>ACCODE</Name>
       <Values>
-        <Value>LaSRC v3.5.2</Value>
+        <Value>LaSRC v3.5.1.0</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>


### PR DESCRIPTION
We're going to append a "maintainer version" to the version we've forked LaSRC from instead of incrementing the patch version to reduce potential confusion. This PR changes the upstream tag to `v3.5.1.0`