### PR TITLE
fix: relax dependencies for container update

### DIFF
--- a/.github/workflows/build_tox_tests.yml
+++ b/.github/workflows/build_tox_tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Tox in docker
         run: |

--- a/.github/workflows/build_tox_tests.yml
+++ b/.github/workflows/build_tox_tests.yml
@@ -9,4 +9,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Tox in docker
-        run: docker compose up --build
+        run: |
+          docker compose build tox
+          docker compose run tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ RUN : \
     git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --no-cache --upgrade setuptools \
-    && pip3 install --no-cache rasterio==1.1.3 tox tox-venv --no-binary rasterio \
+    && pip3 install --no-cache --upgrade setuptools pip \
+    && pip install --no-cache \
+        tox tox-venv \
+        rasterio==1.2.10 --no-binary rasterio \
+        'pyproj>=2,<3' \
     && :
 
 RUN git clone https://github.com/NASA-IMPACT/hls-testing_data

--- a/metadata_creator/metadata_creator.py
+++ b/metadata_creator/metadata_creator.py
@@ -17,8 +17,8 @@ from shapely.geometry import (
     Polygon,
     shape,
     mapping,
-    polygon,
 )
+from shapely.geometry.polygon import orient as orient_polygon
 
 current_dir = os.path.dirname(__file__)
 util_dir = os.path.join(current_dir, "templates")
@@ -367,7 +367,11 @@ class Metadata:
             ):
                 # get list of coordinates from polygons
                 g = shape(record["geometry"])
-                points.extend(list(g.exterior.coords))
+                if isinstance(g, MultiPolygon):
+                    for polygon in g.geoms:
+                        points.extend(list(polygon.exterior.coords))
+                else:
+                    points.extend(list(g.exterior.coords))
 
             # short circuit if there are no points
             if len(points) < 3:
@@ -411,7 +415,7 @@ class Metadata:
             polygons = mpoly.normalize().geoms
             for p in polygons:
                 points = []
-                p = polygon.orient(p, sign=1.0)
+                p = orient_polygon(p, sign=1.0)
                 for x, y in p.exterior.coords[:-1]:
                     points.append(
                         OrderedDict({"PointLongitude": x, "PointLatitude": y})

--- a/metadata_creator/metadata_creator.py
+++ b/metadata_creator/metadata_creator.py
@@ -15,7 +15,7 @@ from shapely.geometry import (
     MultiPoint,
     MultiPolygon,
     Polygon,
-    asShape,
+    shape,
     mapping,
     polygon,
 )
@@ -366,7 +366,7 @@ class Metadata:
                 precision=8,
             ):
                 # get list of coordinates from polygons
-                g = asShape(record["geometry"])
+                g = shape(record["geometry"])
                 points.extend(list(g.exterior.coords))
 
             # short circuit if there are no points

--- a/metadata_creator/metadata_creator.py
+++ b/metadata_creator/metadata_creator.py
@@ -406,7 +406,10 @@ class Metadata:
             if debug:
                 print(gj)
 
-            for p in mpoly:
+            # Normalize to have deterministic vertex and polygon order.
+            # This helps ensure consistency across GEOS/shapely versions.
+            polygons = mpoly.normalize().geoms
+            for p in polygons:
                 points = []
                 p = polygon.orient(p, sign=1.0)
                 for x, y in p.exterior.coords[:-1]:

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ from setuptools import find_packages, setup
 
 setup(
     name="metadata_creator",
-    version="2.7",
+    version="2.8",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "click~=7.1.0",
+        "click",
         "numpy",
-        "pyproj==2.6.1",
+        "pyproj",
         "rasterio",
-        "shapely==1.8a1",
+        "shapely",
         "lxml",
     ],
     extras_require={

--- a/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
+++ b/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
@@ -24,10 +24,6 @@
         <GPolygon>
           <Boundary>
             <Point>
-              <PointLongitude>49.8005509</PointLongitude>
-              <PointLatitude>41.54558877</PointLatitude>
-            </Point>
-            <Point>
               <PointLongitude>51.11703163</PointLongitude>
               <PointLatitude>41.55178512</PointLatitude>
             </Point>
@@ -38,6 +34,10 @@
             <Point>
               <PointLongitude>49.81837971</PointLongitude>
               <PointLatitude>40.55670691</PointLatitude>
+            </Point>
+            <Point>
+              <PointLongitude>49.8005509</PointLongitude>
+              <PointLatitude>41.54558877</PointLatitude>
             </Point>
           </Boundary>
         </GPolygon>

--- a/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
+++ b/tests/data/HLS.L30.39TVF.2020158.165.v1.5.xml
@@ -24,20 +24,20 @@
         <GPolygon>
           <Boundary>
             <Point>
-              <PointLongitude>51.11703163</PointLongitude>
-              <PointLatitude>41.55178512</PointLatitude>
+              <PointLongitude>51.1170186</PointLongitude>
+              <PointLatitude>41.55184248</PointLatitude>
             </Point>
             <Point>
-              <PointLongitude>51.11529156</PointLongitude>
-              <PointLatitude>40.56269239</PointLatitude>
+              <PointLongitude>51.11527873</PointLongitude>
+              <PointLatitude>40.56274929</PointLatitude>
             </Point>
             <Point>
-              <PointLongitude>49.81837971</PointLongitude>
-              <PointLatitude>40.55670691</PointLatitude>
+              <PointLongitude>49.81836515</PointLongitude>
+              <PointLatitude>40.55676366</PointLatitude>
             </Point>
             <Point>
-              <PointLongitude>49.8005509</PointLongitude>
-              <PointLatitude>41.54558877</PointLatitude>
+              <PointLongitude>49.8005361</PointLongitude>
+              <PointLatitude>41.54564597</PointLatitude>
             </Point>
           </Boundary>
         </GPolygon>

--- a/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
+++ b/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
@@ -25,23 +25,31 @@
           <Boundary>
             <Point>
               <PointLongitude>180.0</PointLongitude>
-              <PointLatitude>-10.840859466359879</PointLatitude>
+              <PointLatitude>-10.84086245</PointLatitude>
             </Point>
             <Point>
               <PointLongitude>180.0</PointLongitude>
-              <PointLatitude>-10.85551195129015</PointLatitude>
+              <PointLatitude>-10.853596160180942</PointLatitude>
             </Point>
             <Point>
-              <PointLongitude>179.91877534</PointLongitude>
-              <PointLatitude>-11.22318877</PointLatitude>
+              <PointLongitude>179.99060551442886</PointLongitude>
+              <PointLatitude>-10.85874929986336</PointLatitude>
+            </Point>
+          </Boundary>
+        </GPolygon>
+        <GPolygon>
+          <Boundary>
+            <Point>
+              <PointLongitude>179.99060551442886</PointLongitude>
+              <PointLatitude>-10.85874929986336</PointLatitude>
             </Point>
             <Point>
-              <PointLongitude>179.99993337</PointLongitude>
-              <PointLatitude>-10.85332665</PointLatitude>
+              <PointLongitude>179.89099186</PointLongitude>
+              <PointLatitude>-11.04841104</PointLatitude>
             </Point>
             <Point>
-              <PointLongitude>179.34246202</PointLongitude>
-              <PointLatitude>-10.83375375</PointLatitude>
+              <PointLongitude>179.51697787</PointLongitude>
+              <PointLatitude>-11.11854739</PointLatitude>
             </Point>
           </Boundary>
         </GPolygon>
@@ -49,15 +57,7 @@
           <Boundary>
             <Point>
               <PointLongitude>-180.0</PointLongitude>
-              <PointLatitude>-10.840859466359879</PointLatitude>
-            </Point>
-            <Point>
-              <PointLongitude>-179.99720136</PointLongitude>
-              <PointLatitude>-10.84088971</PointLatitude>
-            </Point>
-            <Point>
-              <PointLongitude>-179.99979252</PointLongitude>
-              <PointLatitude>-10.85332933</PointLatitude>
+              <PointLatitude>-10.84086245</PointLatitude>
             </Point>
             <Point>
               <PointLongitude>-179.99951842</PointLongitude>
@@ -65,7 +65,7 @@
             </Point>
             <Point>
               <PointLongitude>-180.0</PointLongitude>
-              <PointLatitude>-10.85551195129015</PointLatitude>
+              <PointLatitude>-10.853596160180942</PointLatitude>
             </Point>
           </Boundary>
         </GPolygon>

--- a/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
+++ b/tests/data/HLS.S30.T01LAH.2020097T222759.v1.5.xml
@@ -24,6 +24,30 @@
         <GPolygon>
           <Boundary>
             <Point>
+              <PointLongitude>180.0</PointLongitude>
+              <PointLatitude>-10.840859466359879</PointLatitude>
+            </Point>
+            <Point>
+              <PointLongitude>180.0</PointLongitude>
+              <PointLatitude>-10.85551195129015</PointLatitude>
+            </Point>
+            <Point>
+              <PointLongitude>179.91877534</PointLongitude>
+              <PointLatitude>-11.22318877</PointLatitude>
+            </Point>
+            <Point>
+              <PointLongitude>179.99993337</PointLongitude>
+              <PointLatitude>-10.85332665</PointLatitude>
+            </Point>
+            <Point>
+              <PointLongitude>179.34246202</PointLongitude>
+              <PointLatitude>-10.83375375</PointLatitude>
+            </Point>
+          </Boundary>
+        </GPolygon>
+        <GPolygon>
+          <Boundary>
+            <Point>
               <PointLongitude>-180.0</PointLongitude>
               <PointLatitude>-10.840859466359879</PointLatitude>
             </Point>
@@ -42,30 +66,6 @@
             <Point>
               <PointLongitude>-180.0</PointLongitude>
               <PointLatitude>-10.85551195129015</PointLatitude>
-            </Point>
-          </Boundary>
-        </GPolygon>
-        <GPolygon>
-          <Boundary>
-            <Point>
-              <PointLongitude>180.0</PointLongitude>
-              <PointLatitude>-10.85551195129015</PointLatitude>
-            </Point>
-            <Point>
-              <PointLongitude>179.91877534</PointLongitude>
-              <PointLatitude>-11.22318877</PointLatitude>
-            </Point>
-            <Point>
-              <PointLongitude>179.99993337</PointLongitude>
-              <PointLatitude>-10.85332665</PointLatitude>
-            </Point>
-            <Point>
-              <PointLongitude>179.34246202</PointLongitude>
-              <PointLatitude>-10.83375375</PointLatitude>
-            </Point>
-            <Point>
-              <PointLongitude>180.0</PointLongitude>
-              <PointLatitude>-10.840859466359879</PointLatitude>
             </Point>
           </Boundary>
         </GPolygon>

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py36-shapely1x, py36-shapely2x
 
-[testenv]
+[testenv:py{36}-shaeply{1x,2x}]
 basepython = python3.6
+deps =
+    shapely1x: shapely>=1.8,<2
+    shapely2x: shapely==2
 envdir = venv
 sitepackages = True
 extras =
@@ -15,6 +18,10 @@ extras =
 commands =
     flake8
     pytest
+allowlist_externals =
+  flake8
+  mypy
+  pytest
 
 [testenv:dev]
 extras = dev

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36-shapely1x, py36-shapely2x
+envlist = py36
 
-[testenv:py{36}-shaeply{1x,2x}]
+[testenv]
 basepython = python3.6
-deps =
-    shapely1x: shapely>=1.8,<2
-    shapely2x: shapely==2
 envdir = venv
 sitepackages = True
 extras =
@@ -18,10 +15,6 @@ extras =
 commands =
     flake8
     pytest
-allowlist_externals =
-  flake8
-  mypy
-  pytest
 
 [testenv:dev]
 extras = dev


### PR DESCRIPTION
## Description

This PR relaxes the Click, pyproj, and shapely dependencies so this can be installed against a more modern set of dependencies in our atmospheric correction container.

This PR also fixes a number of issues, including test failures from `hls-metadata` unit tests that occur when running in containers like `hls-landsat-tile` (!!).

1. The CI test step did NOT fail if the tests failed when using `docker compose up`. This is problematic because the CI would always succeed even if tests fail!
    - I switched to use `docker compose run` so the exit code from `tox` is used for the `docker compose run` exit.
2. Shapely v2 compat / fix Shapely v1.8 deprecation warnings,
    - Use `shape()` instead of `asShape`
    - Iterate over `MultiPolygon.geoms` instead of using `MultiPolygon.__iter__`
3. Rerender expected output to address vertex and polygon ordering on newer Shapely / GEOS,
    - In Shapely 1.8a1 they used a fairly old version of GEOS. In 1.8.1 they released a wheel compiled against a newer GEOS, and this changed the ordering of vertices and polygons within the MultiPolygon we calculate for the image boundary.
        - Per Shapely, "Discrepancies in behavior compared to previous versions are considered to be improvements." ([ref](https://github.com/shapely/shapely/blob/59bc6a62c7476e953c0159fe825fa4bd22429355/CHANGES.txt#L294-L301))
    - NOTE: If we compiled `shapely==1.8a1` against the GEOS in the container used in this repo, we also get this inconsistency
    - To resolve this I added a `normalize()` call to make the ordering of the vertexes and polygons within a multipolygon deterministic, and rerendered the expected test data
4. Rasterio compatibility, including for the version used in `hls-landsat-tile` container (`1.2.10`)
    - In versions `1.1.1`, `1.1.2`, and `1.1.3` the output of `features.dataset_features()` is a sequence of `Polygon` type-d Features.
    - In `1.1.4` beyond, including `1.2.10` used in our containers, the geometries from each Feature returned _CAN_ be a `list[Polygon | MultiPolygon]`. If we get a `MultiPolygon` we hit an error, `AttributeError: 'MultiPolygonAdapter' object has no attribute 'exterior'`
    - To resolve this I added a if/else to handle a `MultiPolygon` specifically
